### PR TITLE
Enable paging when retrieving data 

### DIFF
--- a/src/main/java/org/tango/jhdb/CassandraSchema.java
+++ b/src/main/java/org/tango/jhdb/CassandraSchema.java
@@ -528,8 +528,7 @@ public class CassandraSchema extends HdbReader {
 
         // Launch asynchronous calls
         boundStatement.setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM);
-        boundStatement.setFetchSize(Integer.MAX_VALUE);
-        //boundStatement.setFetchSize(3600*24*100);
+        boundStatement.setFetchSize(5000);
         resultSetFutures.add(session.executeAsync(boundStatement));
 
       }
@@ -555,6 +554,7 @@ public class CassandraSchema extends HdbReader {
       try {
 
         for (ResultSet rs : resultSets) {
+          int remainingInPage = rs.getAvailableWithoutFetching();
           for (Row rw : rs) {
 
             HdbData hd = HdbData.createData(sigInfo.type);
@@ -673,7 +673,9 @@ public class CassandraSchema extends HdbReader {
                 wvalue                             // Write value
             );
             ret.add(hd);
-
+            remainingInPage--;
+            if((remainingInPage == 100) && !rs.isFullyFetched())
+              rs.fetchMoreResults();
           }
         }
 


### PR DESCRIPTION
…to avoid to put too much memory pressure on the Cassandra nodes.
This should solve the problem which was leading to Cassandra nodes crash (Out of Memory) when a user was requesting a huge amount of data and should trigger garbage collections more often on the Cassandra nodes but much shorter GC stop-of-the-world pauses on the Cassandra nodes than what we observed before.
With this change, the Cassandra timeout can be lower down to a more reasonable value (a few seconds).