### PR TITLE
Select arrays indexes

### DIFF
--- a/src/main/java/org/tango/jhdb/SignalInfo.java
+++ b/src/main/java/org/tango/jhdb/SignalInfo.java
@@ -37,6 +37,8 @@ import org.tango.jhdb.data.HdbData;
 import java.util.Set;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Signal info structure
@@ -188,6 +190,45 @@ public class SignalInfo {
     }
   }
 
+  public static class Range implements Comparable<Range>
+  {
+      int start_idx;
+      int end_idx;
+
+      public static Range FULL_RANGE = new Range(Integer.MIN_VALUE, Integer.MAX_VALUE);
+
+      public Range(int start, int end)
+      {
+          start_idx = start;
+          end_idx = end;
+      }
+
+      public String toString()
+      {
+          if(this == FULL_RANGE)
+              return "";
+          // We set +1 as is postgres indexing starts at 1, it should be done differently.
+          if(start_idx == end_idx)
+              return "[" + (start_idx+1) + "]";
+          return "[" + (start_idx+1) + ":" + (end_idx+1) + "]";
+      }
+
+      public int size()
+      {
+          return end_idx - start_idx + 1;
+      }
+
+      @Override
+      public int compareTo(Range o)
+      {
+          if(start_idx != o.start_idx)
+          {
+              return start_idx - o.start_idx;
+          }
+          return end_idx - o.end_idx;
+      }
+  }
+
   public String  name;          // Attribute name
   public String  sigId;         // Identifier
   public Format  format;        // Data type
@@ -198,6 +239,7 @@ public class SignalInfo {
   public Access  access;        // Write only flag
   public Interval interval = Interval.NONE; // interval, for aggregates
   public Set<HdbData.Aggregate> aggregates;
+  public SortedSet<Integer> indexes;  // For arrays, indexes to be extracted
 
   public SignalInfo()
   {
@@ -215,6 +257,7 @@ public class SignalInfo {
     this.access = parent.access;
     this.interval = parent.interval;
     this.aggregates = parent.aggregates;
+    this.indexes = parent.indexes;
   }
 
   protected SignalInfo(Type type, Format fmt, Access acc)
@@ -345,37 +388,43 @@ public class SignalInfo {
     return Interval.isAggregate(interval);
   }
 
-  /**
-   * Returns true if this signal is aggregated data, false if it is raw.
-   */
-  public String getAggregateQueryList(Map<HdbData.Aggregate, Integer> indexes) {
-    int idx = 0;
-    int nbAggregates = aggregates.size();
-    StringBuffer queryList = new StringBuffer();
-    
-    if(indexes == null)
-    {
-      indexes = new HashMap<>();
-    }
-    
-    for(HdbData.Aggregate agg : aggregates)
-    {
-      queryList.append(agg.toString());
-      
-      if(idx != nbAggregates - 1)
-      {
-        queryList.append(", ");
-      }
-      
-      indexes.put(agg, idx);
-      ++idx;
-    }
-    
-    return queryList.toString();
-  }
-
   public String toString() {
     return "Id=" + sigId + ", Type=" + dataType.toString() + ", Format=" + format.toString() + ", Access=" + access.toString()+ ", Interval=" + interval.toString();
+  }
+
+  public SortedSet<Range> getRanges()
+  {
+      SortedSet<Range> ret = new TreeSet<>();
+      if(indexes == null || indexes.isEmpty())
+      {
+          ret.add(Range.FULL_RANGE);
+      }
+      else
+      {
+          int start = -2;
+          int prev = -2;
+          boolean inRange = false;
+          for(int idx : indexes)
+          {
+              if(idx - prev > 1)
+              {
+                  if(inRange)
+                  {
+                      ret.add(new Range(start, prev));
+                      start = idx;
+                  }
+                  else
+                  {
+                      inRange = true;
+                      start = idx;
+                  }
+              }
+              prev = idx;
+          }
+          if(inRange)
+              ret.add(new Range(start, prev));
+      }
+      return ret;
   }
 
   @Override

--- a/src/main/java/org/tango/jhdb/SignalInfo.java
+++ b/src/main/java/org/tango/jhdb/SignalInfo.java
@@ -35,6 +35,8 @@ package org.tango.jhdb;
 
 import org.tango.jhdb.data.HdbData;
 import java.util.Set;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * Signal info structure
@@ -340,8 +342,37 @@ public class SignalInfo {
    * Returns true if this signal is aggregated data, false if it is raw.
    */
   public boolean isAggregate() {
-        return Interval.isAggregate(interval);
+    return Interval.isAggregate(interval);
+  }
+
+  /**
+   * Returns true if this signal is aggregated data, false if it is raw.
+   */
+  public String getAggregateQueryList(Map<HdbData.Aggregate, Integer> indexes) {
+    int idx = 0;
+    int nbAggregates = aggregates.size();
+    StringBuffer queryList = new StringBuffer();
+    
+    if(indexes == null)
+    {
+      indexes = new HashMap<>();
     }
+    
+    for(HdbData.Aggregate agg : aggregates)
+    {
+      queryList.append(agg.toString());
+      
+      if(idx != nbAggregates - 1)
+      {
+        queryList.append(", ");
+      }
+      
+      indexes.put(agg, idx);
+      ++idx;
+    }
+    
+    return queryList.toString();
+  }
 
   public String toString() {
     return "Id=" + sigId + ", Type=" + dataType.toString() + ", Format=" + format.toString() + ", Access=" + access.toString()+ ", Interval=" + interval.toString();

--- a/src/main/java/org/tango/jhdb/data/HdbData.java
+++ b/src/main/java/org/tango/jhdb/data/HdbData.java
@@ -46,20 +46,32 @@ public abstract class HdbData {
 
   public static enum Aggregate
   {
-    ROWS_COUNT,
-    ERRORS_COUNT,
-    COUNT_R,
-    NAN_COUNT_R,
-    MEAN_R,
-    MIN_R,
-    MAX_R,
-    STDDEV_R,
-    COUNT_W,
-    NAN_COUNT_W,
-    MEAN_W,
-    MIN_W,
-    MAX_W,
-    STDDEV_W,
+    ROWS_COUNT("count_rows"),
+    ERRORS_COUNT("count_errors"),
+    COUNT_R("count_r"),
+    NAN_COUNT_R("count_nan_r"),
+    MEAN_R("mean_r"),
+    MIN_R("min_r"),
+    MAX_R("max_r"),
+    STDDEV_R("stddev_r"),
+    COUNT_W("count_w"),
+    NAN_COUNT_W("count_nan_w"),
+    MEAN_W("mean_w"),
+    MIN_W("min_w"),
+    MAX_W("max_w"),
+    STDDEV_W("stddev_w");
+
+    String description;
+
+    private Aggregate(String desc)
+    {
+      description = desc;
+    }
+
+    public String toString()
+    {
+      return description;
+    }
   }
 
   final protected static Map<Aggregate, List<Number>> EMPTY_AGGREGATE = new EnumMap<>(Aggregate.class);


### PR DESCRIPTION
Allows to extract only some indexes from an array. Only implemented with postgresql.

Note that it is based on the code from PR #7 we might want to merge this one first, or both at the same time.